### PR TITLE
Принуждает гитхаб собрать календарь

### DIFF
--- a/events/2018-05-24-yglf-kyiv.yml
+++ b/events/2018-05-24-yglf-kyiv.yml
@@ -1,3 +1,4 @@
+# Force CI
 name: YGLF Kyiv
 date: 24.05.2018-25.05.2018
 city: Киев, Украина


### PR DESCRIPTION
@pepelsbey смотри, тут такое вынужденное ограничение — чтобы ссылка на календарь для тех, кто подписался давно осталась рабочей  — calendar.ics остаётся в репозитории. 

Но чтобы его добавить — нужен сборочный коммит, который сейчас появляется только в результате мерж-риквеста. Как сделать по-другому и не зациклить сборку — я не придумал.