### PR TITLE
Добавляет 2020-05-27-jamstack-conf.yml

### DIFF
--- a/events/2020-05-27-jamstack-conf.yml
+++ b/events/2020-05-27-jamstack-conf.yml
@@ -1,0 +1,6 @@
+name: Jamstack Conf
+date: 27.05.2020
+time: 14:00-21:00
+city: Лондон
+link: https://jamstackconf.com/virtual/
+online: true


### PR DESCRIPTION
Привет,

В расписании события таймзона указана GMT+1, поэтому городом выбрал Лондон